### PR TITLE
Migrating Express backend server to Heroku / Extracting loginWithCredentials() to its own file

### DIFF
--- a/screens/SigninScreen.js
+++ b/screens/SigninScreen.js
@@ -5,7 +5,9 @@ import FormHeading from '../components/FormHeading';
 import FormInput from '../components/FormInput';
 import GradientView from '../components/GradientView';
 import NextButton from '../components/NextButton';
-import axios from 'axios';
+
+const loginFile = require('../src/auth/login');
+const loginWithCredentials = loginFile.loginWithCredentials;
 
 const SigninScreen = ({ navigation }) => {
     const [email, setEmail] = useState('');
@@ -16,30 +18,6 @@ const SigninScreen = ({ navigation }) => {
     // regex validation for email to determine if we should enable the next button or not
     const emailRegex = /(?!.*\.{2})^([a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+(\.[a-z\d!#$%&'*+\-\/=?^_`{|}~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+)*|"((([\t]*\r\n)?[\t]+)?([\x01-\x08\x0b\x0c\x0e-\x1f\x7f\x21\x23-\x5b\x5d-\x7e\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|\\[\x01-\x09\x0b\x0c\x0d-\x7f\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))*(([\t]*\r\n)?[\t]+)?")@(([a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[a-z\d\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])\.)+([a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]|[a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF][a-z\d\-._~\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]*[a-z\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])\.?$/i;
     let isEmailValid = emailRegex.test(String(email).toLowerCase());
-
-    // NOTE: Replace this IP with the private IP address of your computer. Do not 
-    // use localhost, since that refers to the simulator. 
-    function loginWithCredentials() {
-        // Make the GET request to our local NodeJS backend server targeting
-        // '/users' resource with the provided parameters. 
-        axios.get('http://192.168.68.130:3000/users', {
-            params: {
-                email: email,
-                password: password
-            }
-        }) // TODO: update to log error when connection to express server fails
-          .then(function (response) {
-            console.log('response.data:')
-            console.log(response.data);
-            if (response.data.length == 1) {
-                console.log('User logged in!');
-                navigation.navigate('TabNav');
-            } else if (response.data.length < 1) {
-                console.log('Failed to log user in.');
-                
-            }
-          });
-      }
 
     return (
         <GradientView>
@@ -67,7 +45,25 @@ const SigninScreen = ({ navigation }) => {
             />
             <Image source={require('../assets/icons/name_input_bar.png')} style={styles.nameBar} />
             <Text style={styles.forgotPassword}>forgot your password?</Text>
-            { isEmailValid && password.length > 0 && <NextButton onPress={() => loginWithCredentials()} marginTop={45} /> }
+            {
+                isEmailValid && password.length > 0 &&
+                <NextButton
+                    onPress={async () => {
+                        try {
+                            const response = await loginWithCredentials(email, password);
+                            console.log('response = ' + response);
+                            if (response) {
+                                navigation.navigate('TabNav');
+                            } else {
+                                console.log('Auth request failed');
+                            }
+                        } catch (e) {
+                            console.log('err happened: ' + e);
+                        }
+                    }}
+                    marginTop={45}
+                />
+            }
         </GradientView>
     );
 };

--- a/src/auth/login.js
+++ b/src/auth/login.js
@@ -1,22 +1,33 @@
+import axios from 'axios';
+
 module.exports = {
-    loginWithCredentials: function() {
-    // Make the GET request to our local NodeJS backend server targeting
-    // '/users' resource with the provided parameters. 
-    axios.get('https://flix-express.herokuapp.com/users', {
-        params: {
-            email: email,
-            password: password
-        }
-    }) // TODO: update to log error when connection to express server fails
-      .then(function (response) {
-        console.log('response.data:')
-        console.log(response.data);
-        if (response.data.length == 1) {
-            console.log('User logged in!');
-            navigation.navigate('TabNav');
-        } else if (response.data.length < 1) {
-            console.log('Failed to log user in.');
-            
-        }
-      });
+    loginWithCredentials: function(email, password) {
+        let loggedIn;
+        // Make the GET request to our local NodeJS backend server targeting
+        // '/users' resource with the provided parameters.
+        return new Promise ((resolve, reject) => {
+            axios.get('https://flix-express.herokuapp.com/users', {
+            // axios.get('http://192.168.68.130:3000/users', {
+                params: {
+                    email: email,
+                    password: password
+                }
+            }) // TODO: update to log error when connection to express server fails
+            .then(function (response) {
+                    console.log('response.data:')
+                    console.log(response.data);
+                    if (response.data.length == 1) {
+                        console.log('User logged in!');
+                        loggedIn = true;
+                        resolve(true);
+                    } else if (response.data.length < 1) {
+                        console.log('Failed to log user in.');
+                        loggedIn = false;
+                        resolve(false);
+                        reject(true);
+                    }
+                }
+            );
+        });
+    },
 }

--- a/src/auth/login.js
+++ b/src/auth/login.js
@@ -1,0 +1,22 @@
+module.exports = {
+    loginWithCredentials: function() {
+    // Make the GET request to our local NodeJS backend server targeting
+    // '/users' resource with the provided parameters. 
+    axios.get('https://flix-express.herokuapp.com/users', {
+        params: {
+            email: email,
+            password: password
+        }
+    }) // TODO: update to log error when connection to express server fails
+      .then(function (response) {
+        console.log('response.data:')
+        console.log(response.data);
+        if (response.data.length == 1) {
+            console.log('User logged in!');
+            navigation.navigate('TabNav');
+        } else if (response.data.length < 1) {
+            console.log('Failed to log user in.');
+            
+        }
+      });
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -34,7 +34,13 @@ app.get('/users', function (req, res) {
     });
 });
 
-app.listen(3000, () => {
-    console.log('Go to http://localhost:3000/users so you can see the data!');
+
+let port = process.env.PORT;
+if (port == null || port == "") {
+    port = 3000;
+}
+app.listen(port, () => {
+    const url = 'https://flix-express.herokuapp.com/users?email=humzam99%40gmail.com&password=ghi%40678'
+    console.log('Go to ' + url + ' so you can see the data!');
 })
 


### PR DESCRIPTION
Currently we're just running a local server for our Express backend service, which means you as a developer have to run the `node` command each time to spin up the server on your computer when you want to start using the app (obviously not great). We will be using Heroku now, which will a much more sustainable, long term solution as it is actually hosted in the cloud. We're on a free account as well (for now). New URL is **https://flix-express.herokuapp.com/**. Of course, we don't have any routes set up there, so if you want to test it out you can go to [this link to see my data](https://flix-express.herokuapp.com/users?email=humzam99%40gmail.com&password=ghi%40678) pulled live from the AWS SQL DB.

The Heroku app is actually maintained and deployed through a separate Git repo, so I'll have to get that pushed up to my GitHub account and add you all to that as well.  

Please try to pull the latest code on this branch and test out my changes for yourself. Make sure you can still login as there was a lot of moving pieces to this. 